### PR TITLE
Added fixed characters to adminPassword

### DIFF
--- a/template/sql_vm.bicep
+++ b/template/sql_vm.bicep
@@ -10,7 +10,7 @@ var sqlVirtualMachineName = 'pvlab-${randomString}-sqlvm'
 
 var adminUsername = 'sqladmin${randomString}'
 var upperString = toUpper(randomString)
-var adminPassword = '${randomString}!${upperString}@${randomString}'
+var adminPassword = '${randomString}!${upperString}@${randomString}0aA'
 
 resource networkInterface_resource 'Microsoft.Network/networkInterfaces@2018-10-01' = {
   name: 'pvlab-${randomString}-ni'


### PR DESCRIPTION
For issue #58 - Added fixed characters to adminPassword to avoid deploy errors when the first 6 characters of a resource group ID consist only of numbers or alphabetic letters.