### PR TITLE
Update azuredeploy.json to allow multiple deployments per RG

### DIFF
--- a/template/azuredeploy.json
+++ b/template/azuredeploy.json
@@ -10,7 +10,7 @@
   },
   "variables": {
     "location": "[resourceGroup().location]",
-    "randomString": "[substring(guid(resourceGroup().id), 0, 6)]",
+    "randomString": "[substring(guid(resourceGroup().id, deployment().name), 0, 6)]",
     "roleDefinitionprefix": "[format('/subscriptions/{0}/providers/Microsoft.Authorization/roleDefinitions', subscription().subscriptionId)]",
     "role": {
       "Owner": "[format('{0}/8e3af657-a8ff-443c-a75c-2fe8c4bcb635', variables('roleDefinitionprefix'))]",
@@ -194,7 +194,7 @@
       "type": "Microsoft.Authorization/roleAssignments",
       "apiVersion": "2020-08-01-preview",
       "scope": "[format('Microsoft.Storage/storageAccounts/{0}', format('pvlab{0}synapse', variables('randomString')))]",
-      "name": "[guid(resourceGroup().id)]",
+      "name": "[guid(resourceGroup().id, deployment().name)]",
       "properties": {
         "principalId": "[reference(format('pvlab-{0}-synapse', variables('randomString')), '2021-05-01', 'full').identity.principalId]",
         "roleDefinitionId": "[variables('role').StorageBlobDataContributor]",
@@ -363,7 +363,7 @@
               "location": "[parameters('location')]",
               "properties": {
                 "hardwareProfile": {
-                  "vmSize": "Standard_B2ms"
+                  "vmSize": "Standard_D2ads_v5"
                 },
                 "storageProfile": {
                   "osDisk": {


### PR DESCRIPTION
Changed vmSize due to the old one not being available in West US 2. The new one (Standard D2ads_v5) appears to be available broadly Make changes that allow this deployment to be ran more than once in a given resource group: 
1. Changed the role assignment guid from guid of RG to guid of RG+Deployment name
2. Changed randomString variable assignment to use substring of the guid (instead of just the RG) to be a substring of the guid of the RG+Deployment name